### PR TITLE
Fix address parsing and make API configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,7 +1156,7 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexer"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "bitcoincore-rpc",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "network-shared"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bincode",
  "chrono",
@@ -1894,7 +1894,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix-web",
  "bincode",

--- a/README.md
+++ b/README.md
@@ -68,10 +68,13 @@ docker-compose up -d
 | RPC_PORT | Bitcoin RPC port | 18443 |
 | RPC_USER | Bitcoin RPC username | user |
 | RPC_PASSWORD | Bitcoin RPC password | password |
+| NETWORK | Bitcoin network (mainnet, testnet, regtest, signet) | regtest |
 | SOCKET_PATH | Path to Unix socket | /tmp/network-utxos.sock |
 | START_HEIGHT | Block height to start from | 0 |
 | POLLING_RATE | Polling interval in milliseconds | 500 |
 | MAX_BLOCKS_PER_BATCH | Maximum blocks to process in a batch | 200 |
+| API_HOST | API server host | 0.0.0.0 |
+| API_PORT | API server port | 3031 |
 
 ### network-utxos
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - START_HEIGHT=${INDEXER_START_BLOCK:-0}
       - POLLING_RATE=${INDEXER_POLLING_RATE:-500}
       - MAX_BLOCKS_PER_BATCH=${INDEXER_MAX_BLOCKS:-200}
+      - API_HOST=0.0.0.0
+      - API_PORT=3031
     networks:
       - bitcoin_network
     depends_on:

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -45,7 +45,9 @@ ENV SOCKET_PATH="/tmp/network-utxos.sock" \
     RPC_PASSWORD="password" \
     START_HEIGHT=0 \
     POLLING_RATE=500 \
-    MAX_BLOCKS_PER_BATCH=200
+    MAX_BLOCKS_PER_BATCH=200 \
+    API_HOST=0.0.0.0 \
+    API_PORT=3031
 
 # Use shell form to allow environment variable expansion
 CMD indexer \
@@ -57,4 +59,6 @@ CMD indexer \
     --rpc-password "$RPC_PASSWORD" \
     --start-height "$START_HEIGHT" \
     --polling-rate "$POLLING_RATE" \
-    --max-blocks-per-batch "$MAX_BLOCKS_PER_BATCH"
+    --max-blocks-per-batch "$MAX_BLOCKS_PER_BATCH" \
+    --api-host "$API_HOST" \
+    --api-port "$API_PORT"

--- a/network-shared/Cargo.toml
+++ b/network-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-shared"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- validate bitcoin addresses against the configured network
- allow configuring API server host and port
- propagate network into API server
- expose new settings in Docker and compose files
- bump crate versions

## Testing
- `cargo check --all --locked` *(fails: could not download dependencies)*