### PR TITLE
Add UTXO selection and signing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ docker-compose up -d
 | API_HOST | API server host | 0.0.0.0 |
 | API_PORT | API server port | 3031 |
 | ENCLAVE_URL | URL of the enclave service | - |
+| UTXO_URL | URL of the UTXO database service | http://network-utxos:5557 |
+| ENCLAVE_API_KEY | API key for enclave requests | - |
 
 ### network-utxos
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,8 @@ services:
       - API_HOST=0.0.0.0
       - API_PORT=3031
       - ENCLAVE_URL=http://enclave:5555
+      - UTXO_URL=http://network-utxos:5557
+      - ENCLAVE_API_KEY=
     networks:
       - bitcoin_network
     depends_on:

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -48,7 +48,9 @@ ENV SOCKET_PATH="/tmp/network-utxos.sock" \
     MAX_BLOCKS_PER_BATCH=200 \
     API_HOST=0.0.0.0 \
     API_PORT=3031 \
-    ENCLAVE_URL="http://network-enclave:5555"
+    ENCLAVE_URL="http://network-enclave:5555" \
+    UTXO_URL="http://network-utxos:5557" \
+    ENCLAVE_API_KEY=""
 
 # Use shell form to allow environment variable expansion
 CMD indexer \

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -91,11 +91,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )?;
 
     let enclave_url = std::env::var("ENCLAVE_URL").expect("ENCLAVE_URL must be set");
+    let utxo_url = std::env::var("UTXO_URL").unwrap_or_else(|_| "http://network-utxos:5557".to_string());
+    let enclave_api_key = std::env::var("ENCLAVE_API_KEY").unwrap_or_default();
 
     let api_state = ApiState {
         watched_addresses: indexer.watched_addresses(),
         network,
         enclave_url,
+        utxo_url,
+        enclave_api_key,
     };
 
     // Run HTTP server in background


### PR DESCRIPTION
## Summary
- expose new `POST /select-utxos` and `POST /sign-transaction` endpoints in the indexer API
- forward signing requests to the enclave with `X-API-Key`
- allow querying spendable UTXOs from the storage service
- configure URLs and API key via environment variables
- document new variables and update Docker configs

## Testing
- `cargo check` *(fails: failed to download crates)*