### PR TITLE
Refactor indexer config and cleanup

### DIFF
--- a/indexer/src/error.rs
+++ b/indexer/src/error.rs
@@ -1,4 +1,3 @@
-use bitcoincore_rpc;
 use network_shared::TransportError;
 use std::error::Error;
 use std::fmt;

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -12,7 +12,7 @@ use reqwest::Url;
 use tokio::task;
 
 use crate::api::{run_server, ApiState};
-use crate::indexer::BitcoinIndexer;
+use crate::indexer::{BitcoinIndexer, IndexerConfig};
 
 /// Command line arguments for the Bitcoin indexer
 #[derive(Parser, Debug)]
@@ -108,17 +108,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let args = Args::parse();
 
-    let network = args.parse_network();
-    let mut indexer = BitcoinIndexer::new(
-        network,
-        &args.rpc_user,
-        &args.rpc_password,
-        &args.rpc_host,
-        args.rpc_port,
-        &args.socket_path,
-        args.start_height,
-        args.max_blocks_per_batch,
-    )?;
+    let config = IndexerConfig {
+        network: args.parse_network(),
+        rpc_user: args.rpc_user.clone(),
+        rpc_password: args.rpc_password.clone(),
+        rpc_host: args.rpc_host.clone(),
+        rpc_port: args.rpc_port,
+        socket_path: args.socket_path.clone(),
+        start_height: args.start_height,
+        max_blocks_per_batch: args.max_blocks_per_batch,
+    };
+    let mut indexer = BitcoinIndexer::new(config)?;
 
     let enclave_url = std::env::var("ENCLAVE_URL").expect("ENCLAVE_URL must be set");
     validate_enclave_url(&enclave_url).expect("Invalid ENCLAVE_URL");

--- a/indexer/src/utils.rs
+++ b/indexer/src/utils.rs
@@ -26,5 +26,5 @@ pub fn extract_public_key(witness: &Witness) -> Option<String> {
     if witness.is_empty() {
         return None;
     }
-    witness.iter().nth(1).map(|pk| hex::encode(pk))
+    witness.iter().nth(1).map(hex::encode)
 }

--- a/storage/src/datasources/csv.rs
+++ b/storage/src/datasources/csv.rs
@@ -190,8 +190,8 @@ impl Datasource for UtxoCSVDatasource {
             if let Some(address_utxos) = utxos.get_mut(&utxo.address) {
                 if let Some(existing_utxo) = address_utxos.get_mut(&utxo_id) {
                     existing_utxo.spent_txid = utxo.spent_txid.clone();
-                    existing_utxo.spent_at = utxo.spent_at.clone();
-                    existing_utxo.spent_block = utxo.spent_block.clone();
+                    existing_utxo.spent_at = utxo.spent_at;
+                    existing_utxo.spent_block = utxo.spent_block;
                 }
             }
         }
@@ -259,7 +259,7 @@ impl Datasource for UtxoCSVDatasource {
             .read()
             .get(&block_height)
             .and_then(|block_data| block_data.get(address))
-            .map(|utxos| utxos.clone())
+            .cloned()
             .unwrap_or_default();
 
         Ok(result)


### PR DESCRIPTION
## Summary
- clean up redundant imports
- encapsulate indexer initialization parameters in `IndexerConfig`
- adjust main to build the new `IndexerConfig`
- simplify witness hex encoding
- remove unnecessary clones in CSV datasource

## Testing
- `rustup component add clippy` *(fails: No route to host)*
- `cargo build` *(fails: failed to download crates)*