### PR TITLE
Fix Docker build context

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,12 +38,14 @@ jobs:
       packages: write
       contents: read
     strategy:
-      matrix:
-        include:
-          - context: ./indexer
-            image_name: network-indexer
-          - context: ./storage
-            image_name: network-utxos
+        matrix:
+          include:
+            - context: .
+              dockerfile: indexer/Dockerfile
+              image_name: network-indexer
+            - context: .
+              dockerfile: storage/Dockerfile
+              image_name: network-utxos
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -66,7 +68,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: ${{ matrix.context }}
-          file: ${{ matrix.context }}/Dockerfile
+          file: ${{ matrix.dockerfile }}
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |


### PR DESCRIPTION
## Summary
- fix build context for GitHub Actions matrix entries so Dockerfile can access workspace

## Testing
- `cargo test --locked` *(fails: failed to download from crates.io)*