### PR TITLE
Secure sign-transaction endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The indexer exposes an HTTP API used by validators:
 - `GET /watch-address/{address}` - check if an address is watched
 - `POST /derive-address` - derive a Bitcoin address from an EVM address (forwarded to the signing service)
 - `POST /select-utxos` - select UTXOs across watched addresses for a target amount
-- `POST /sign-transaction` - proxy a signing request to the configured signing service
+- `POST /sign-transaction` - proxy a signing request to the configured signing service (requires `X-API-Key` header)
 
 *Note: querying data for blocks less than 6 blocks behind the chain tip are subject to change based on the reorg mechanics described below.*
 
@@ -103,6 +103,7 @@ docker-compose up -d
 | ENCLAVE_URL | URL of the signing service (enclave) | - |
 | UTXO_URL | URL of the UTXO database service | http://network-utxos:5557 |
 | ENCLAVE_API_KEY | API key sent when proxying signing requests | - |
+| INDEXER_API_KEY | API key required for `/sign-transaction` | - |
 
 ### network-utxos
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       ENCLAVE_URL: ${ENCLAVE_URL:-http://enclave:5555}
       UTXO_URL: ${UTXO_URL:-http://network-utxos:5557}
       ENCLAVE_API_KEY: ${ENCLAVE_API_KEY:-}
+      INDEXER_API_KEY: ${INDEXER_API_KEY:-}
     ports:
       - "3031:3031"
     networks:

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -50,7 +50,8 @@ ENV SOCKET_PATH="/tmp/network-utxos.sock" \
     API_PORT=3031 \
     ENCLAVE_URL="http://network-enclave:5555" \
     UTXO_URL="http://network-utxos:5557" \
-    ENCLAVE_API_KEY=""
+    ENCLAVE_API_KEY="" \
+    INDEXER_API_KEY=""
 
 # Use shell form to allow environment variable expansion
 CMD indexer \

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -131,12 +131,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
         panic!("ENCLAVE_API_KEY must be set");
     }
 
+    let indexer_api_key = std::env::var("INDEXER_API_KEY").expect("INDEXER_API_KEY must be set");
+    if indexer_api_key.trim().is_empty() {
+        panic!("INDEXER_API_KEY must be set");
+    }
+
     let api_state = ApiState {
         watched_addresses: indexer.watched_addresses(),
         network: args.parse_network(),
         enclave_url,
         utxo_url,
         enclave_api_key,
+        indexer_api_key,
     };
 
     // Run HTTP server in background


### PR DESCRIPTION
## Summary
- require API key for `/sign-transaction`
- support new `INDEXER_API_KEY` env var in indexer
- document API key usage and update docker artefacts

## Testing
- `cargo check --workspace` *(fails: Could not connect to server)*