### PR TITLE
Add SQLite indexes

### DIFF
--- a/storage/src/datasources/sqlite.rs
+++ b/storage/src/datasources/sqlite.rs
@@ -67,6 +67,15 @@ impl UtxoSqliteDatasource {
                     UNIQUE(txid, vout)
                 )",
             ),
+            M::up(
+                "CREATE INDEX IF NOT EXISTS idx_utxo_address ON utxo(address)"
+            ),
+            M::up(
+                "CREATE INDEX IF NOT EXISTS idx_utxo_block_height ON utxo(block_height)"
+            ),
+            M::up(
+                "CREATE INDEX IF NOT EXISTS idx_utxo_spent_block ON utxo(spent_block)"
+            ),
         ]);
 
         let mut conn = self


### PR DESCRIPTION
## Summary
- add indexes for address, block_height and spent_block columns in migrations

## Testing
- `cargo check` *(fails: failed to get bincode as a dependency because the environment lacks network access)*