### PR TITLE
Implement strict Bitcoin address validation

### DIFF
--- a/storage/src/network/mod.rs
+++ b/storage/src/network/mod.rs
@@ -1,10 +1,14 @@
 use std::sync::Arc;
 
+use bitcoin::Network;
+
 use crate::database::UtxoDatabase;
 
 #[derive(Clone)]
 pub struct AppState {
     pub db: Arc<UtxoDatabase>,
+    /// The Bitcoin network this instance is operating on
+    pub network: Network,
 }
 
 pub mod http;


### PR DESCRIPTION
## Summary
- parse Bitcoin network from CLI for storage service
- track network in application state
- add helper for address parsing with network check
- enforce address validation in HTTP handlers

## Testing
- `cargo check --workspace` *(fails: Could not connect to server)*