### PR TITLE
Fix clippy warning by using shared struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,7 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexer"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "bitcoincore-rpc",
@@ -1499,7 +1499,7 @@ dependencies = [
 
 [[package]]
 name = "network-shared"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bincode",
  "chrono",
@@ -2157,7 +2157,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "storage"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "actix-web",
  "bincode",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 
 use bitcoincore_rpc::bitcoin::{address::NetworkUnchecked, Address, Amount, Network};
 use log::{debug, error, info};
+use network_shared::StoreSignedTxRequest;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::str::FromStr;
 use tokio::sync::RwLock;
 use warp::{http::StatusCode, Filter, Reply};
-use network_shared::StoreSignedTxRequest;
 
 /// Maximum allowed size for JSON request bodies (32 KiB)
 const MAX_JSON_BODY_SIZE: u64 = 32 * 1024;
@@ -345,7 +345,10 @@ async fn fetch_selected_utxos(
     ))
 }
 
-async fn store_signed_tx(state: &ApiState, req: &StoreSignedTxRequest) -> Result<(), reqwest::Error> {
+async fn store_signed_tx(
+    state: &ApiState,
+    req: &StoreSignedTxRequest,
+) -> Result<(), reqwest::Error> {
     let client = reqwest::Client::new();
     let url = format!("{}/signed-tx", state.utxo_url);
     let body = json!(req);

--- a/network-shared/Cargo.toml
+++ b/network-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-shared"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/network-shared/src/lib.rs
+++ b/network-shared/src/lib.rs
@@ -44,6 +44,17 @@ pub struct UtxoUpdate {
     pub spent_block: Option<i32>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StoreSignedTxRequest {
+    pub txid: String,
+    pub signed_tx: String,
+    pub caller: String,
+    pub block_height: i32,
+    pub amount: i64,
+    pub destination: String,
+    pub fee: i64,
+}
+
 // Socket transport implementation for sender side
 pub struct SocketTransport {
     socket_path: String,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [dependencies]

--- a/storage/src/network/http.rs
+++ b/storage/src/network/http.rs
@@ -8,8 +8,8 @@ use std::str::FromStr;
 
 use super::AppState;
 use crate::error::StorageError;
-use serde::Deserialize;
 use network_shared::StoreSignedTxRequest;
+use serde::Deserialize;
 
 fn parse_bitcoin_address(address: &str, expected_network: Network) -> Result<Address, String> {
     let addr =
@@ -371,7 +371,6 @@ async fn get_utxo_by_outpoint(
         }
     }
 }
-
 
 #[instrument(skip(state, body))]
 async fn store_signed_tx(

--- a/storage/src/network/http.rs
+++ b/storage/src/network/http.rs
@@ -9,6 +9,7 @@ use std::str::FromStr;
 use super::AppState;
 use crate::error::StorageError;
 use serde::Deserialize;
+use network_shared::StoreSignedTxRequest;
 
 fn parse_bitcoin_address(address: &str, expected_network: Network) -> Result<Address, String> {
     let addr =
@@ -371,16 +372,6 @@ async fn get_utxo_by_outpoint(
     }
 }
 
-#[derive(Deserialize)]
-struct StoreSignedTxRequest {
-    txid: String,
-    signed_tx: String,
-    caller: String,
-    block_height: i32,
-    amount: i64,
-    destination: String,
-    fee: i64,
-}
 
 #[instrument(skip(state, body))]
 async fn store_signed_tx(


### PR DESCRIPTION
## Summary
- add `StoreSignedTxRequest` struct to network-shared crate
- update indexer to use new struct when storing signed txs
- update storage HTTP server to accept new struct

## Testing
- `cargo clippy --quiet` *(fails: 'cargo-clippy' not installed)*
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6849a711afc08328a6a8c638b4f358bc