### PR TITLE
Add prepare transaction caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "bech32",
  "bitcoin-internals",
- "bitcoin_hashes 0.13.0",
+ "bitcoin_hashes",
  "bitcoinconsensus",
  "hex-conservative",
  "hex_lit",
@@ -379,21 +379,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9425c3bf7089c983facbae04de54513cce73b41c7f9ff8c845b54e7bc64ebbfb"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
 ]
 
 [[package]]
@@ -1264,6 +1249,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "warp",
 ]
@@ -1995,7 +1981,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
- "bitcoin_hashes 0.12.0",
+ "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -2088,6 +2074,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -17,3 +17,4 @@ serde_json.workspace = true
 tokio.workspace = true
 warp = "0.3"
 reqwest = { version = "0.11", features = ["json"] }
+sha2 = "0.10"

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -102,11 +102,11 @@ struct EnclaveSignResponse {
 fn parse_bitcoin_address(addr: &str, network: Network) -> Result<Address, String> {
     let address_unchecked: Address<NetworkUnchecked> = addr
         .parse()
-        .map_err(|e| format!("Address parse error: {:?}", e))?;
+        .map_err(|e| format!("Address parse error: {e:?}"))?;
 
     address_unchecked
         .require_network(network)
-        .map_err(|e| format!("Network mismatch: {:?}", e))
+        .map_err(|e| format!("Network mismatch: {e:?}"))
 }
 
 pub async fn watch_address_handler(

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -1,6 +1,7 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use bitcoincore_rpc::bitcoin::{address::NetworkUnchecked, Address, Amount, Network};
 use log::{debug, error, info};
@@ -10,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::str::FromStr;
 use tokio::sync::RwLock;
+use sha2::{Digest, Sha256};
 use warp::{http::StatusCode, Filter, Reply};
 
 /// Maximum allowed size for JSON request bodies (32 KiB)
@@ -23,6 +25,7 @@ pub struct ApiState {
     pub utxo_url: String,
     pub enclave_api_key: String,
     pub indexer_api_key: String,
+    pub prepare_tx_cache: Arc<RwLock<HashMap<String, CachedPrepareResponse>>>,
 }
 
 fn with_state(state: ApiState) -> impl Filter<Extract = (ApiState,), Error = Infallible> + Clone {
@@ -82,6 +85,15 @@ pub struct PrepareTransactionRequest {
 pub struct PrepareTransactionResponse {
     pub txid: String,
 }
+
+#[derive(Debug, Clone)]
+pub struct CachedPrepareResponse {
+    pub response: PrepareTransactionResponse,
+    pub created_at: Instant,
+    pub selected_utxos: Vec<network_shared::UtxoUpdate>,
+}
+
+const CACHE_EXPIRY_DURATION: Duration = Duration::from_secs(300);
 
 #[derive(Deserialize)]
 struct EnclaveSignResponse {
@@ -345,6 +357,114 @@ async fn fetch_selected_utxos(
     ))
 }
 
+fn generate_prepare_tx_cache_key(req: &PrepareTransactionRequest) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(req.block_height.to_le_bytes());
+    hasher.update(req.amount.to_le_bytes());
+    hasher.update(req.fee.to_le_bytes());
+    hasher.update(req.destination.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+async fn clean_expired_cache_entries(
+    cache: &Arc<RwLock<HashMap<String, CachedPrepareResponse>>>,
+) {
+    let mut cache_write = cache.write().await;
+    let now = Instant::now();
+    cache_write.retain(|_, entry| now.duration_since(entry.created_at) < CACHE_EXPIRY_DURATION);
+}
+
+async fn fetch_selected_utxos_deterministic(
+    state: &ApiState,
+    block_height: i32,
+    total_needed: i64,
+) -> Result<Vec<network_shared::UtxoUpdate>, (serde_json::Value, StatusCode)> {
+    let client = reqwest::Client::new();
+    let mut selected_utxos = Vec::new();
+    let mut total_selected = 0;
+
+    let watched_addresses = {
+        let addr_set = state.watched_addresses.read().await;
+        let mut addresses: Vec<_> = addr_set.iter().cloned().collect();
+        addresses.sort_by(|a, b| a.to_string().cmp(&b.to_string()));
+        addresses
+    };
+
+    for addr in watched_addresses.iter() {
+        if total_selected >= total_needed {
+            break;
+        }
+
+        let remaining_needed = total_needed - total_selected;
+        let url = format!(
+            "{}/select-utxos/block/{}/address/{}/amount/{}",
+            state.utxo_url, block_height, addr, remaining_needed
+        );
+
+        let resp = client.get(&url).send().await.map_err(|e| {
+            error!("Failed to request UTXOs: {}", e);
+            (
+                json!({ "error": "Failed to fetch UTXOs" }),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let err_text = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "Unknown error".to_string());
+            error!("UTXO service error (status {}): {}", status, err_text);
+            return Err((
+                json!({ "error": format!("UTXO service error: {}", err_text) }),
+                StatusCode::BAD_GATEWAY,
+            ));
+        }
+
+        let value = resp.json::<serde_json::Value>().await.map_err(|e| {
+            error!("Failed to parse UTXO response: {}", e);
+            (
+                json!({ "error": "Invalid UTXO response" }),
+                StatusCode::INTERNAL_SERVER_ERROR,
+            )
+        })?;
+
+        let utxos: Vec<network_shared::UtxoUpdate> =
+            serde_json::from_value(value.get("selected_utxos").cloned().unwrap_or_default())
+                .map_err(|e| {
+                    error!("UTXO JSON structure incorrect: {}", e);
+                    (
+                        json!({ "error": "Malformed UTXO data" }),
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                    )
+                })?;
+
+        for utxo in utxos {
+            total_selected += utxo.amount;
+            selected_utxos.push(utxo);
+
+            if total_selected >= total_needed {
+                debug!("Collected sufficient UTXOs: {}", total_selected);
+                break;
+            }
+        }
+    }
+
+    if total_selected < total_needed {
+        error!(
+            "Insufficient UTXOs: Needed {}, got {}",
+            total_needed, total_selected
+        );
+        return Err((
+            json!({ "error": "Insufficient funds across watched addresses" }),
+            StatusCode::BAD_REQUEST,
+        ));
+    }
+
+    Ok(selected_utxos)
+}
+
 async fn store_signed_tx(
     state: &ApiState,
     req: &StoreSignedTxRequest,
@@ -580,7 +700,7 @@ pub async fn sign_transaction_handler(
     }
 }
 
-pub async fn prepare_transaction_handler(
+pub async fn prepare_transaction_handler_idempotent(
     api_key: String,
     req: PrepareTransactionRequest,
     state: ApiState,
@@ -589,9 +709,26 @@ pub async fn prepare_transaction_handler(
         let resp = warp::reply::json(&json!({ "error": "Unauthorized" }));
         return Ok(warp::reply::with_status(resp, StatusCode::UNAUTHORIZED));
     }
+
+    let cache_key = generate_prepare_tx_cache_key(&req);
+    clean_expired_cache_entries(&state.prepare_tx_cache).await;
+
+    {
+        let cache_read = state.prepare_tx_cache.read().await;
+        if let Some(cached_entry) = cache_read.get(&cache_key) {
+            if Instant::now().duration_since(cached_entry.created_at) < CACHE_EXPIRY_DURATION {
+                info!("Returning cached prepare transaction result for key: {}", cache_key);
+                return Ok(warp::reply::with_status(
+                    warp::reply::json(&cached_entry.response),
+                    StatusCode::OK,
+                ));
+            }
+        }
+    }
+
     let total_needed = req.amount + req.fee;
 
-    let selected_utxos = match fetch_selected_utxos(&state, req.block_height, total_needed).await {
+    let selected_utxos = match fetch_selected_utxos_deterministic(&state, req.block_height, total_needed).await {
         Ok(list) => list,
         Err((msg, status)) => {
             return Ok(warp::reply::with_status(warp::reply::json(&msg), status));
@@ -619,9 +756,24 @@ pub async fn prepare_transaction_handler(
     };
 
     let txid = unsigned_tx.txid().to_string();
+    let response = PrepareTransactionResponse { txid };
+
+    {
+        let mut cache_write = state.prepare_tx_cache.write().await;
+        cache_write.insert(
+            cache_key.clone(),
+            CachedPrepareResponse {
+                response: response.clone(),
+                created_at: Instant::now(),
+                selected_utxos,
+            },
+        );
+    }
+
+    info!("Cached prepare transaction result for key: {}", cache_key);
 
     Ok(warp::reply::with_status(
-        warp::reply::json(&PrepareTransactionResponse { txid }),
+        warp::reply::json(&response),
         StatusCode::OK,
     ))
 }
@@ -674,7 +826,7 @@ pub async fn run_server(host: &str, port: u16, state: ApiState) {
         .and(warp::header::<String>("x-api-key"))
         .and(json_prepare_tx)
         .and(with_state(state.clone()))
-        .and_then(prepare_transaction_handler);
+        .and_then(prepare_transaction_handler_idempotent);
 
     let sign_tx_route = warp::post()
         .and(warp::path("sign-transaction"))

--- a/indexer/src/error.rs
+++ b/indexer/src/error.rs
@@ -14,10 +14,10 @@ pub enum IndexerError {
 impl fmt::Display for IndexerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            IndexerError::BitcoinRPC(e) => write!(f, "Bitcoin RPC error: {}", e),
-            IndexerError::Network(e) => write!(f, "Network error: {}", e),
+            IndexerError::BitcoinRPC(e) => write!(f, "Bitcoin RPC error: {e}"),
+            IndexerError::Network(e) => write!(f, "Network error: {e}"),
             IndexerError::InvalidTimestamp => write!(f, "Invalid timestamp"),
-            IndexerError::InvalidStartBlock(msg) => write!(f, "Invalid start block: {}", msg),
+            IndexerError::InvalidStartBlock(msg) => write!(f, "Invalid start block: {msg}"),
         }
     }
 }

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -3,12 +3,13 @@ mod error;
 mod indexer;
 mod utils;
 
-use std::{error::Error, net::IpAddr, time::Duration};
+use std::{collections::HashMap, error::Error, net::IpAddr, sync::Arc, time::Duration};
 
 use bitcoincore_rpc::bitcoin::Network;
 
 use clap::Parser;
 use reqwest::Url;
+use tokio::sync::RwLock;
 use tokio::task;
 
 use crate::api::{run_server, ApiState};
@@ -150,6 +151,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         utxo_url,
         enclave_api_key,
         indexer_api_key,
+        prepare_tx_cache: Arc::new(RwLock::new(HashMap::new())),
     };
 
     // Run HTTP server in background

--- a/network-shared/src/error.rs
+++ b/network-shared/src/error.rs
@@ -19,8 +19,8 @@ impl From<bincode::Error> for TransportError {
 impl std::fmt::Display for TransportError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TransportError::IoError(e) => write!(f, "IO error: {}", e),
-            TransportError::SerializationError(e) => write!(f, "Serialization error: {}", e),
+            TransportError::IoError(e) => write!(f, "IO error: {e}"),
+            TransportError::SerializationError(e) => write!(f, "Serialization error: {e}"),
         }
     }
 }

--- a/storage/src/datasources/mod.rs
+++ b/storage/src/datasources/mod.rs
@@ -45,8 +45,7 @@ pub fn create_datasource(arg: &str) -> StorageResult<Arc<dyn Datasource + Send +
             Ok(datasource as Arc<dyn Datasource + Send + Sync>)
         }
         _ => Err(StorageError::UnexpectedError(format!(
-            "Invalid argument for datasource: {}, Use 'csv' or 'sqlite'",
-            arg
+            "Invalid argument for datasource: {arg}, Use 'csv' or 'sqlite'",
         ))),
     }
 }

--- a/storage/src/datasources/sqlite.rs
+++ b/storage/src/datasources/sqlite.rs
@@ -165,7 +165,7 @@ impl Datasource for UtxoSqliteDatasource {
 
         // Start a transaction
         let tx = conn.transaction().map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {e}"))
         })?;
 
         // Upsert UTXOs from utxos_update
@@ -192,7 +192,7 @@ impl Datasource for UtxoSqliteDatasource {
 
         // Commit the transaction
         tx.commit().map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to commit transaction: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to commit transaction: {e}"))
         })?;
 
         Ok(())
@@ -228,7 +228,7 @@ impl Datasource for UtxoSqliteDatasource {
             AND address = ?2",
             )
             .map_err(|e| {
-                StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {}", e))
+                StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {e}"))
             })?;
 
         let mut results = Vec::new();
@@ -261,17 +261,14 @@ impl Datasource for UtxoSqliteDatasource {
                     spent_block: row.get(12)?,
                 })
             })
-            .map_err(|e| {
-                StorageError::DatabaseQueryFailed(format!("Failed to query rows: {}", e))
-            })?;
+            .map_err(|e| StorageError::DatabaseQueryFailed(format!("Failed to query rows: {e}")))?;
 
         for row in rows {
             match row {
                 Ok(utxo) => results.push(utxo),
                 Err(e) => {
                     return Err(StorageError::DatabaseQueryFailed(format!(
-                        "Failed to process row: {}",
-                        e
+                        "Failed to process row: {e}"
                     )))
                 }
             }
@@ -309,7 +306,7 @@ impl Datasource for UtxoSqliteDatasource {
 
         // Prepare the statement
         let mut stmt = conn.prepare(query).map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {e}"))
         })?;
 
         // Execute the query and map results to UtxoUpdate
@@ -340,9 +337,7 @@ impl Datasource for UtxoSqliteDatasource {
                     spent_block: row.get(12)?,
                 })
             })
-            .map_err(|e| {
-                StorageError::DatabaseQueryFailed(format!("Failed to query rows: {}", e))
-            })?;
+            .map_err(|e| StorageError::DatabaseQueryFailed(format!("Failed to query rows: {e}")))?;
 
         // Collect the results into a vector
         let mut results = Vec::new();
@@ -351,8 +346,7 @@ impl Datasource for UtxoSqliteDatasource {
                 Ok(utxo) => results.push(utxo),
                 Err(e) => {
                     return Err(StorageError::DatabaseQueryFailed(format!(
-                        "Failed to process row: {}",
-                        e
+                        "Failed to process row: {e}"
                     )))
                 }
             }
@@ -381,7 +375,7 @@ impl Datasource for UtxoSqliteDatasource {
         ";
 
         let mut stmt = conn.prepare(query).map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to prepare statement: {e}"))
         })?;
 
         let rows = stmt
@@ -411,9 +405,7 @@ impl Datasource for UtxoSqliteDatasource {
                     spent_block: row.get(12)?,
                 })
             })
-            .map_err(|e| {
-                StorageError::DatabaseQueryFailed(format!("Failed to query rows: {}", e))
-            })?;
+            .map_err(|e| StorageError::DatabaseQueryFailed(format!("Failed to query rows: {e}")))?;
 
         let mut results = Vec::new();
         for row in rows {
@@ -421,8 +413,7 @@ impl Datasource for UtxoSqliteDatasource {
                 Ok(utxo) => results.push(utxo),
                 Err(e) => {
                     return Err(StorageError::DatabaseQueryFailed(format!(
-                        "Failed to process row: {}",
-                        e
+                        "Failed to process row: {e}",
                     )))
                 }
             }
@@ -532,7 +523,7 @@ impl Datasource for UtxoSqliteDatasource {
             .map_err(|e| StorageError::DatabaseConnectionFailed(e.to_string()))?;
 
         let tx = conn.transaction().map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {e}"))
         })?;
 
         // 1. Unspend UTXOs that were spent after this height
@@ -551,7 +542,7 @@ impl Datasource for UtxoSqliteDatasource {
             .map_err(|e| StorageError::DatabaseQueryFailed(e.to_string()))?;
 
         tx.commit().map_err(|e| {
-            StorageError::DatabaseQueryFailed(format!("Failed to commit transaction: {}", e))
+            StorageError::DatabaseQueryFailed(format!("Failed to commit transaction: {e}"))
         })?;
 
         Ok(())

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -44,7 +44,7 @@ impl fmt::Display for StorageError {
                 f,
                 "Insufficient funds: available={available}, required={required}",
             ),
-            StorageError::InvalidAddress(addr) => write!(f, "Invalid address: {}", addr),
+            StorageError::InvalidAddress(addr) => write!(f, "Invalid address: {addr}"),
             StorageError::InvalidBlockHeight(height) => {
                 write!(f, "Invalid block height: {height}")
             }

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -30,29 +30,28 @@ pub enum StorageError {
 impl fmt::Display for StorageError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            StorageError::IoError(s) => write!(f, "I/O error: {}", s),
+            StorageError::IoError(s) => write!(f, "I/O error: {s}"),
             StorageError::DatabaseConnectionFailed(s) => {
-                write!(f, "Database connection failed: {}", s)
+                write!(f, "Database connection failed: {s}")
             }
-            StorageError::DatabaseQueryFailed(s) => write!(f, "Database query failed: {}", s),
-            StorageError::MigrationFailed(s) => write!(f, "Migration failed: {}", s),
-            StorageError::BlockNotFound(height) => write!(f, "Block not found: height={}", height),
+            StorageError::DatabaseQueryFailed(s) => write!(f, "Database query failed: {s}"),
+            StorageError::MigrationFailed(s) => write!(f, "Migration failed: {s}"),
+            StorageError::BlockNotFound(height) => write!(f, "Block not found: height={height}"),
             StorageError::InsufficientFunds {
                 available,
                 required,
             } => write!(
                 f,
-                "Insufficient funds: available={}, required={}",
-                available, required
+                "Insufficient funds: available={available}, required={required}",
             ),
             StorageError::InvalidAddress(addr) => write!(f, "Invalid address: {}", addr),
             StorageError::InvalidBlockHeight(height) => {
-                write!(f, "Invalid block height: {}", height)
+                write!(f, "Invalid block height: {height}")
             }
-            StorageError::InvalidAmount(amount) => write!(f, "Invalid amount: {}", amount),
-            StorageError::SerializationFailed(s) => write!(f, "Serialization failed: {}", s),
-            StorageError::DeserializationFailed(s) => write!(f, "Deserialization failed: {}", s),
-            StorageError::UnexpectedError(s) => write!(f, "Unexpected error: {}", s),
+            StorageError::InvalidAmount(amount) => write!(f, "Invalid amount: {amount}"),
+            StorageError::SerializationFailed(s) => write!(f, "Serialization failed: {s}"),
+            StorageError::DeserializationFailed(s) => write!(f, "Deserialization failed: {s}"),
+            StorageError::UnexpectedError(s) => write!(f, "Unexpected error: {s}"),
         }
     }
 }

--- a/storage/src/main.rs
+++ b/storage/src/main.rs
@@ -51,7 +51,7 @@ impl Args {
             "testnet" => Network::Testnet,
             "regtest" => Network::Regtest,
             "signet" => Network::Signet,
-            other => panic!("Unsupported network: {}", other),
+            other => panic!("Unsupported network: {other}"),
         }
     }
 }
@@ -73,24 +73,22 @@ async fn main() -> std::io::Result<()> {
         Err(e) => {
             error!("Failed to create datasource: {}", e);
             return Err(std::io::Error::other(format!(
-                "Failed to create datasource: {}",
-                e
+                "Failed to create datasource: {e}",
             )));
         }
     };
 
     // Initialize datasource
     if let Err(e) = datasource.setup() {
-        error!("Failed to setup datasource: {}", e);
+        error!("Failed to setup datasource: {e}");
         return Err(std::io::Error::other(format!(
-            "Failed to setup datasource: {}",
-            e
+            "Failed to setup datasource: {e}",
         )));
     }
 
     // Create databases
     let db = UtxoDatabase::new(datasource);
-    let signed_db = SignedTxDatabase::new().map_err(|e| std::io::Error::other(format!("{}", e)))?;
+    let signed_db = SignedTxDatabase::new().map_err(|e| std::io::Error::other(format!("{e}")))?;
 
     // Determine the Bitcoin network this instance should operate on
     let network = args.parse_network();
@@ -105,7 +103,7 @@ async fn main() -> std::io::Result<()> {
     let db_clone = db.clone();
     tokio::spawn(async move {
         if let Err(e) = run_socket_server(db_clone, &socket_path).await {
-            error!("Socket server error: {}", e);
+            error!("Socket server error: {e}");
         }
     });
 

--- a/storage/src/network/http.rs
+++ b/storage/src/network/http.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 
 fn parse_bitcoin_address(address: &str, expected_network: Network) -> Result<Address, String> {
     let addr =
-        Address::from_str(address).map_err(|e| format!("Invalid Bitcoin address format: {}", e))?;
+        Address::from_str(address).map_err(|e| format!("Invalid Bitcoin address format: {e}"))?;
 
     addr.require_network(expected_network)
         .map_err(|e| format!("Bitcoin address network mismatch: {}", e))
@@ -64,9 +64,9 @@ async fn get_latest_block(state: web::Data<AppState>) -> HttpResponse {
             HttpResponse::Ok().json(response)
         }
         Err(e) => {
-            error!("Failed to get latest block: {}", e);
+            error!("Failed to get latest block: {e}");
             HttpResponse::InternalServerError().json(json!({
-                "error": format!("Failed to retrieve latest block: {}", e)
+                "error": format!("Failed to retrieve latest block: {e}")
             }))
         }
     }

--- a/storage/src/network/http.rs
+++ b/storage/src/network/http.rs
@@ -16,7 +16,7 @@ fn parse_bitcoin_address(address: &str, expected_network: Network) -> Result<Add
         Address::from_str(address).map_err(|e| format!("Invalid Bitcoin address format: {e}"))?;
 
     addr.require_network(expected_network)
-        .map_err(|e| format!("Bitcoin address network mismatch: {}", e))
+        .map_err(|e| format!("Bitcoin address network mismatch: {e}"))
 }
 
 pub fn configure_routes(cfg: &mut web::ServiceConfig) {

--- a/storage/src/network/socket.rs
+++ b/storage/src/network/socket.rs
@@ -44,8 +44,7 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
     if let Err(e) = stream.read_exact(&mut size_buf).await {
         // Handle gracefully disconnects or short reads
         return Err(std::io::Error::other(format!(
-            "Failed to read message size: {}",
-            e
+            "Failed to read message size: {e}",
         )));
     }
 
@@ -55,8 +54,7 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
     let mut data = vec![0u8; size];
     if let Err(e) = stream.read_exact(&mut data).await {
         return Err(std::io::Error::other(format!(
-            "Failed to read message data: {}",
-            e
+            "Failed to read message data: {e}",
         )));
     }
 
@@ -65,8 +63,7 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
         Ok(msg) => msg,
         Err(e) => {
             return Err(std::io::Error::other(format!(
-                "Failed to deserialize message: {}",
-                e
+                "Failed to deserialize message: {e}",
             )));
         }
     };
@@ -79,12 +76,12 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
 
             // Store block information
             if let Err(e) = db.store_block(height, &update.hash, update.timestamp) {
-                error!("Error storing block info: {}", e);
+                error!("Error storing block info: {e}");
             }
 
             // Process the update
             if let Err(e) = db.process_block(update).await {
-                error!("Error processing block: {}", e);
+                error!("Error processing block: {e}");
             }
 
             // Send acknowledgment
@@ -100,7 +97,7 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
 
             // Handle the reorg
             if let Err(e) = db.revert_to_height(fork_height).await {
-                error!("Error handling reorg: {}", e);
+                error!("Error handling reorg: {e}");
             }
         }
         network_shared::NetworkMessage::GetBlockHash { height } => {
@@ -131,7 +128,7 @@ async fn handle_socket_connection(stream: UnixStream, db: Arc<UtxoDatabase>) -> 
             );
 
             if let Err(e) = db.update_finality_status(current_height).await {
-                error!("Error updating finality status: {}", e);
+                error!("Error updating finality status: {e}");
             }
         }
         _ => {


### PR DESCRIPTION
## Summary
- implement idempotent prepare-transaction handler with cache
- expose cache in ApiState and wire into main
- use deterministic UTXO selection
- add sha2 dependency

## Testing
- `cargo build --workspace` *(fails: could not download crates)*
- `cargo test --workspace` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687e79b1224c83288c33f089ef43fc2f