### PR TITLE
Improve prepare transaction cache persistence

### DIFF
--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -154,7 +154,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         enclave_api_key,
         indexer_api_key,
         prepare_tx_cache: Arc::new(RwLock::new(prepare_tx_cache)),
+        shutdown_tx: None,
     };
+
+    let cache_clone = api_state.prepare_tx_cache.clone();
+    tokio::spawn(async move {
+        crate::api::start_cache_persistence_task(cache_clone).await;
+    });
 
     // Run HTTP server in background
     let api_host = args.api_host.clone();


### PR DESCRIPTION
## Summary
- add temporary cache file constant and shutdown sender field
- introduce `clean_expired_cache_entries_and_persist` for atomic writes
- load cache safely and back up corrupted files
- start a periodic task to persist the cache
- avoid persisting on every cache insertion

## Testing
- `cargo fmt --all` *(fails: rustfmt missing)*
- `cargo check -p indexer` *(fails: could not download crates)*

------
https://chatgpt.com/codex/tasks/task_e_687e91be1a2c8328ad3438499345e27c