### PR TITLE
Add persistence for prepare transaction cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,7 +1236,7 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexer"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "bitcoincore-rpc",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "network-shared"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "bincode",
  "chrono",
@@ -2154,7 +2154,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "storage"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "actix-web",
  "bincode",

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -93,7 +93,7 @@ pub struct CachedPrepareResponse {
     pub created_at: DateTime<Utc>,
 }
 
-const PREPARE_TX_CACHE_FILE: &str = "prepare_tx_cache.json";
+const PREPARE_TX_CACHE_FILE: &str = "/app/cache/prepare_tx_cache.json";
 
 #[derive(Deserialize)]
 struct EnclaveSignResponse {

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -373,6 +373,17 @@ pub async fn load_prepare_tx_cache() -> HashMap<String, CachedPrepareResponse> {
     }
 }
 
+pub async fn save_prepare_tx_cache(
+    cache: &tokio::sync::RwLock<HashMap<String, CachedPrepareResponse>>,
+) -> std::io::Result<()> {
+    let data = {
+        let cache_read = cache.read().await;
+        serde_json::to_vec(&*cache_read)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+    };
+    tokio::fs::write(PREPARE_TX_CACHE_FILE, data).await
+}
+
 async fn fetch_selected_utxos_deterministic(
     state: &ApiState,
     block_height: i32,
@@ -767,6 +778,10 @@ pub async fn prepare_transaction_handler_idempotent(
                 created_at: Utc::now(),
             },
         );
+    }
+
+    if let Err(e) = save_prepare_tx_cache(&state.prepare_tx_cache).await {
+        error!("Failed to save prepare transaction cache: {}", e);
     }
 
     info!("Cached prepare transaction result for key: {}", cache_key);

--- a/indexer/src/api.rs
+++ b/indexer/src/api.rs
@@ -297,7 +297,7 @@ async fn fetch_selected_utxos(
         );
 
         let resp = client.get(&url).send().await.map_err(|e| {
-            error!("Failed to request UTXOs: {}", e);
+            error!("Failed to request UTXOs: {e}");
             (
                 json!({ "error": "Failed to fetch UTXOs" }),
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/network-shared/Cargo.toml
+++ b/network-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network-shared"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storage"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- persist `prepare_tx_cache` to disk
- log any errors that occur when writing the file

## Testing
- `cargo test --all --quiet` *(fails: failed to download from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b42cea083289f6c598543752cbc