### PR TITLE
Implement UTXO fetch batching and caching

### DIFF
--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -19,3 +19,4 @@ warp = "0.3"
 reqwest = { version = "0.11", features = ["json"] }
 sha2 = "0.10"
 async-trait = "0.1"
+lru = "0.12"

--- a/storage/src/datasources/csv.rs
+++ b/storage/src/datasources/csv.rs
@@ -202,6 +202,22 @@ impl Datasource for UtxoCSVDatasource {
         Ok(())
     }
 
+    fn bulk_upsert_utxos(&self, utxos: &[UtxoUpdate]) -> StorageResult<()> {
+        let mut pending = PendingChanges {
+            height: 0,
+            utxos_update: Vec::new(),
+            utxos_insert: Vec::new(),
+        };
+        for utxo in utxos {
+            if utxo.spent_txid.is_some() {
+                pending.utxos_update.push(utxo.clone());
+            } else {
+                pending.utxos_insert.push(utxo.clone());
+            }
+        }
+        self.process_block_utxos(&pending)
+    }
+
     fn get_spendable_utxos_at_height(
         &self,
         block_height: i32,

--- a/storage/src/datasources/mod.rs
+++ b/storage/src/datasources/mod.rs
@@ -14,6 +14,7 @@ pub trait Datasource {
     fn get_type(&self) -> String;
     fn get_latest_block(&self) -> StorageResult<i32>;
     fn process_block_utxos(&self, pending_changes: &PendingChanges) -> StorageResult<()>;
+    fn bulk_upsert_utxos(&self, utxos: &[UtxoUpdate]) -> StorageResult<()>;
     fn get_spendable_utxos_at_height(
         &self,
         block_height: i32,

--- a/storage/src/datasources/sqlite.rs
+++ b/storage/src/datasources/sqlite.rs
@@ -123,6 +123,66 @@ impl UtxoSqliteDatasource {
 
         Ok(())
     }
+
+    fn bulk_upsert_utxos_in_tx(tx: &rusqlite::Transaction, utxos: &[UtxoUpdate]) -> StorageResult<()> {
+        let mut stmt = tx.prepare(
+            "INSERT INTO utxo (
+                id, address, public_key, txid, vout, amount, script_pub_key,
+                script_type, created_at, block_height, spent_txid, spent_at, spent_block
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+            ON CONFLICT(id) DO UPDATE SET
+                spent_txid = excluded.spent_txid,
+                spent_at = excluded.spent_at,
+                spent_block = excluded.spent_block" )
+            .map_err(|e| StorageError::DatabaseQueryFailed(e.to_string()))?;
+
+        for utxo in utxos {
+            if utxo.amount < 0 {
+                return Err(StorageError::InvalidAmount(utxo.amount));
+            }
+            if utxo.address.is_empty() {
+                return Err(StorageError::InvalidAddress("Empty address".to_string()));
+            }
+            stmt.execute(params![
+                utxo.id,
+                utxo.address,
+                utxo.public_key,
+                utxo.txid,
+                utxo.vout,
+                utxo.amount,
+                utxo.script_pub_key,
+                utxo.script_type,
+                utxo.created_at.to_rfc3339(),
+                utxo.block_height,
+                utxo.spent_txid,
+                utxo.spent_at.map(|dt| dt.to_rfc3339()),
+                utxo.spent_block,
+            ])
+            .map_err(|e| StorageError::DatabaseQueryFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    pub fn bulk_upsert_utxos_impl(&self, utxos: &[UtxoUpdate]) -> StorageResult<()> {
+        let mut conn = self
+            .conn
+            .get()
+            .map_err(|e| StorageError::DatabaseConnectionFailed(e.to_string()))?;
+
+        let tx = conn.transaction().map_err(|e| {
+            StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {e}"))
+        })?;
+
+        if let Err(e) = Self::bulk_upsert_utxos_in_tx(&tx, utxos) {
+            let _ = tx.rollback();
+            return Err(e);
+        }
+
+        tx.commit().map_err(|e| {
+            StorageError::DatabaseQueryFailed(format!("Failed to commit transaction: {e}"))
+        })?;
+        Ok(())
+    }
 }
 
 impl Datasource for UtxoSqliteDatasource {
@@ -168,26 +228,12 @@ impl Datasource for UtxoSqliteDatasource {
             StorageError::DatabaseQueryFailed(format!("Failed to start transaction: {e}"))
         })?;
 
-        // Upsert UTXOs from utxos_update
-        for utxo in &changes.utxos_update {
-            if let Err(e) = UtxoSqliteDatasource::upsert_utxo_in_tx(&tx, utxo) {
-                let _ = tx.rollback(); // Try to rollback, but we'll return the original error
-                return Err(StorageError::DatabaseQueryFailed(format!(
-                    "Failed to upsert UTXO {}: {}",
-                    utxo.id, e
-                )));
-            }
-        }
-
-        // Upsert UTXOs from utxos_insert
-        for utxo in &changes.utxos_insert {
-            if let Err(e) = UtxoSqliteDatasource::upsert_utxo_in_tx(&tx, utxo) {
-                let _ = tx.rollback(); // Try to rollback, but we'll return the original error
-                return Err(StorageError::DatabaseQueryFailed(format!(
-                    "Failed to upsert UTXO {}: {}",
-                    utxo.id, e
-                )));
-            }
+        let mut all_utxos = Vec::new();
+        all_utxos.extend_from_slice(&changes.utxos_update);
+        all_utxos.extend_from_slice(&changes.utxos_insert);
+        if let Err(e) = UtxoSqliteDatasource::bulk_upsert_utxos_in_tx(&tx, &all_utxos) {
+            let _ = tx.rollback();
+            return Err(e);
         }
 
         // Commit the transaction
@@ -591,5 +637,9 @@ impl Datasource for UtxoSqliteDatasource {
             .map_err(|e| StorageError::DatabaseQueryFailed(e.to_string()))?;
 
         Ok(result)
+    }
+
+    fn bulk_upsert_utxos(&self, utxos: &[UtxoUpdate]) -> StorageResult<()> {
+        self.bulk_upsert_utxos_impl(utxos)
     }
 }


### PR DESCRIPTION
## Summary
- batch outpoint lookup requests using `JoinSet`
- add LRU caches for transactions and UTXOs
- rework transaction processing to use batched fetches
- support bulk upserts in SQLite datasource and expose through trait

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_688a211a9b9083289eaec8bf5d812f68