### PR TITLE
Add CLI log level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ docker-compose up -d
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| RUST_LOG | Log level | info |
+| RUST_LOG | Log level (env_logger) | info |
+| LOG_LEVEL | CLI log level | info |
 | RPC_HOST | Bitcoin RPC host url | http://bitcoin-regtest:18443 |
 | RPC_USER | Bitcoin RPC username | user |
 | RPC_PASSWORD | Bitcoin RPC password | password |

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ docker-compose up -d
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| RUST_LOG | Log level (env_logger) | info |
-| LOG_LEVEL | CLI log level | info |
+| LOG_LEVEL | Log level | info |
 | RPC_HOST | Bitcoin RPC host url | http://bitcoin-regtest:18443 |
 | RPC_USER | Bitcoin RPC username | user |
 | RPC_PASSWORD | Bitcoin RPC password | password |
@@ -120,7 +119,6 @@ docker-compose up -d
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| RUST_LOG | Log level | info |
 | HOST | Host to bind HTTP server | 0.0.0.0 |
 | PORT | HTTP server port | 5557 |
 | LOG_LEVEL | Log level | info |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,7 +96,6 @@ services:
       context: .
       dockerfile: ./indexer/Dockerfile
     environment:
-      - RUST_LOG=${LOG_LEVEL}
       - LOG_LEVEL=${LOG_LEVEL}
       - NETWORK=${BITCOIN_NETWORK}
       - RPC_HOST=${BITCOIN_RPC_URL:-http://bitcoin-regtest:18443}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       dockerfile: ./indexer/Dockerfile
     environment:
       - RUST_LOG=${LOG_LEVEL}
+      - LOG_LEVEL=${LOG_LEVEL}
       - NETWORK=${BITCOIN_NETWORK}
       - RPC_HOST=${BITCOIN_RPC_URL:-http://bitcoin-regtest:18443}
       - RPC_CONNECTION_TYPE=${BITCOIN_CONNECTION_TYPE:-bitcoincore}

--- a/example.env
+++ b/example.env
@@ -80,7 +80,7 @@ UTXO_DATASOURCE=sqlite
 # LOGGING CONFIGURATION (Required for both options)
 # =============================================================================
 
-# Log level
+# Log level for indexer and storage services
 LOG_LEVEL=info
 
 # =============================================================================

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -39,6 +39,7 @@ USER service
 
 # Set environment variables
 ENV RUST_LOG=info
+ENV LOG_LEVEL=info
 
 # Set default values for arguments
 ENV SOCKET_PATH="/tmp/network-utxos.sock" \
@@ -69,4 +70,5 @@ CMD indexer \
     --polling-rate "$POLLING_RATE" \
     --max-blocks-per-batch "$MAX_BLOCKS_PER_BATCH" \
     --api-host "$API_HOST" \
-    --api-port "$API_PORT"
+    --api-port "$API_PORT" \
+    --log-level "$LOG_LEVEL"

--- a/indexer/Dockerfile
+++ b/indexer/Dockerfile
@@ -38,7 +38,6 @@ RUN useradd -m -u 1001 service && \
 USER service
 
 # Set environment variables
-ENV RUST_LOG=info
 ENV LOG_LEVEL=info
 
 # Set default values for arguments

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -152,7 +152,7 @@ fn validate_enclave_url(url_str: &str) -> Result<(), String> {
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
-    env_logger::Builder::from_default_env()
+    env_logger::Builder::new()
         .filter_level(args.log_level.parse().unwrap_or(log::LevelFilter::Info))
         .init();
 

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -52,6 +52,9 @@ pub struct Args {
     #[arg(long, default_value = "0")]
     pub start_height: i32,
 
+    #[arg(long, default_value = "info", help = "Log level")]
+    pub log_level: String,
+
     #[arg(
         long,
         default_value = "0",
@@ -147,11 +150,11 @@ fn validate_enclave_url(url_str: &str) -> Result<(), String> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::Builder::from_default_env()
-        .filter_level(log::LevelFilter::Debug)
-        .init();
-
     let args = Args::parse();
+
+    env_logger::Builder::from_default_env()
+        .filter_level(args.log_level.parse().unwrap_or(log::LevelFilter::Info))
+        .init();
 
     let utxo_url =
         std::env::var("UTXO_URL").unwrap_or_else(|_| "http://network-utxos:5557".to_string());

--- a/storage/Dockerfile
+++ b/storage/Dockerfile
@@ -40,8 +40,6 @@ RUN useradd -m -u 1001 service && \
     chown -R service:service /data
 
 # Set environment variables
-ENV RUST_LOG=info
-
 # Set default values for arguments
 ENV HOST=0.0.0.0 \
     PORT=5557 \


### PR DESCRIPTION
## Summary
- add `log_level` CLI arg to indexer
- wire log level setup in indexer main
- expose LOG_LEVEL in indexer Dockerfile and compose file
- document log level arg and env vars
- note log level usage in example.env

## Testing
- `cargo fmt --all`
- `cargo check --workspace` *(fails: failed to download from crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_688ba5618dd88328bc3c2a3f8bf2aad3